### PR TITLE
Bump DeterministicIoPackaging to 0.20.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="DeterministicIoPackaging" Version="0.19.0" />
+    <PackageVersion Include="DeterministicIoPackaging" Version="0.20.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.4.1" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="28.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />


### PR DESCRIPTION
Update the central package version for DeterministicIoPackaging from 0.19.0 to 0.20.0 in Directory.Packages.props so all projects use the 0.20.0 release.