### PR TITLE
Capture validation enforcement and column metadata in snapshot

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;CA1416;NU1608;NU1109</NoWarn>
-    <Version>1.10.0</Version>
+    <Version>1.11.0</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>OpenXML, Verify</PackageTags>

--- a/src/Tests/ExcelValidationTests.ValidationsAndRequiredAndLocked#00.verified.txt
+++ b/src/Tests/ExcelValidationTests.ValidationsAndRequiredAndLocked#00.verified.txt
@@ -22,7 +22,9 @@
               Contract
             ],
             AllowBlank: false,
+            ShowInputMessage: true,
             InputMessage: Pick one,
+            ShowErrorMessage: true,
             ErrorTitle: Invalid,
             ErrorMessage: Pick a status from the list.,
             Range: 2-100
@@ -40,6 +42,8 @@
             Min: 2020-01-01,
             Max: 2030-12-31,
             AllowBlank: true,
+            ShowInputMessage: false,
+            ShowErrorMessage: false,
             Range: 2-100
           }
         },
@@ -55,6 +59,8 @@
             Min: 0,
             Max: 100,
             AllowBlank: true,
+            ShowInputMessage: false,
+            ShowErrorMessage: false,
             Range: 2-100
           }
         },

--- a/src/Tests/ExcelValidationTests.ValidationsAndRequiredAndLocked#01.verified.txt
+++ b/src/Tests/ExcelValidationTests.ValidationsAndRequiredAndLocked#01.verified.txt
@@ -22,7 +22,9 @@
               Contract
             ],
             AllowBlank: false,
+            ShowInputMessage: true,
             InputMessage: Pick one,
+            ShowErrorMessage: true,
             ErrorTitle: Invalid,
             ErrorMessage: Pick a status from the list.,
             Range: 2-100
@@ -40,6 +42,8 @@
             Min: 2020-01-01,
             Max: 2030-12-31,
             AllowBlank: true,
+            ShowInputMessage: false,
+            ShowErrorMessage: false,
             Range: 2-100
           }
         },
@@ -55,6 +59,8 @@
             Min: 0,
             Max: 100,
             AllowBlank: true,
+            ShowInputMessage: false,
+            ShowErrorMessage: false,
             Range: 2-100
           }
         },

--- a/src/Verify.OpenXml/Info.cs
+++ b/src/Verify.OpenXml/Info.cs
@@ -23,6 +23,7 @@ class SheetInfo
 class ColumnInfo
 {
     public required string Name { get; init; }
+    public string? PropertyName { get; init; }
     public double? Width { get; init; }
     public bool ContainsRichText { get; init; }
     public string? NumberFormat { get; init; }
@@ -39,8 +40,11 @@ class ColumnValidationInfo
     public string? Min { get; init; }
     public string? Max { get; init; }
     public bool AllowBlank { get; init; }
+    public bool ShowInputMessage { get; init; }
     public string? InputTitle { get; init; }
     public string? InputMessage { get; init; }
+    public bool ShowErrorMessage { get; init; }
+    public string? ErrorStyle { get; init; }
     public string? ErrorTitle { get; init; }
     public string? ErrorMessage { get; init; }
     public string? Range { get; init; }

--- a/src/Verify.OpenXml/VerifyOpenXml_Excel.cs
+++ b/src/Verify.OpenXml/VerifyOpenXml_Excel.cs
@@ -64,14 +64,21 @@ public static partial class VerifyOpenXml
     internal static List<SheetInfo> BuildSheetInfos(WorkbookPart workbookPart)
     {
         var sheetInfos = new List<SheetInfo>();
+        var propertyNames = ReadColumnPropertyNames(workbookPart);
 
         foreach (var sheetElement in workbookPart.Workbook!.Sheets!.Elements<Sheet>())
         {
             var worksheetPart = (WorksheetPart) workbookPart.GetPartById(sheetElement.Id!);
+            var sheetName = sheetElement.Name!.Value!;
             var columns = GetColumnInfos(worksheetPart, workbookPart);
+            if (columns != null && propertyNames.TryGetValue(sheetName, out var sheetProps))
+            {
+                ApplyPropertyNames(columns, sheetProps);
+            }
+
             var sheetInfo = new SheetInfo
             {
-                Name = sheetElement.Name!.Value!,
+                Name = sheetName,
                 Columns = columns is { Count: > 0 } ? columns : null,
                 Protection = BuildSheetProtectionInfo(worksheetPart)
             };
@@ -79,6 +86,78 @@ public static partial class VerifyOpenXml
         }
 
         return sheetInfos;
+    }
+
+    static void ApplyPropertyNames(List<ColumnInfo> columns, IReadOnlyDictionary<int, string> propertyNames)
+    {
+        for (var i = 0; i < columns.Count; i++)
+        {
+            if (propertyNames.TryGetValue(i + 1, out var name))
+            {
+                var existing = columns[i];
+                columns[i] = new()
+                {
+                    Name = existing.Name,
+                    PropertyName = name,
+                    Width = existing.Width,
+                    ContainsRichText = existing.ContainsRichText,
+                    NumberFormat = existing.NumberFormat,
+                    Locked = existing.Locked,
+                    RequiredHighlight = existing.RequiredHighlight,
+                    Validation = existing.Validation
+                };
+            }
+        }
+    }
+
+    static Dictionary<string, IReadOnlyDictionary<int, string>> ReadColumnPropertyNames(WorkbookPart workbookPart)
+    {
+        var result = new Dictionary<string, IReadOnlyDictionary<int, string>>();
+        const string ns = "http://schemas.simoncropp.com/excelsior/v1";
+
+        foreach (var part in workbookPart.CustomXmlParts)
+        {
+            using var stream = part.GetStream(System.IO.FileMode.Open, System.IO.FileAccess.Read);
+            System.Xml.Linq.XDocument doc;
+            try
+            {
+                doc = System.Xml.Linq.XDocument.Load(stream);
+            }
+            catch
+            {
+                continue;
+            }
+
+            var root = doc.Root;
+            if (root == null || root.Name.NamespaceName != ns || root.Name.LocalName != "excelsior")
+            {
+                continue;
+            }
+
+            foreach (var sheetElement in root.Elements(System.Xml.Linq.XName.Get("sheet", ns)))
+            {
+                var sheetName = sheetElement.Attribute("name")?.Value;
+                if (sheetName == null)
+                {
+                    continue;
+                }
+
+                var columnMap = new Dictionary<int, string>();
+                foreach (var col in sheetElement.Elements(System.Xml.Linq.XName.Get("column", ns)))
+                {
+                    var indexAttr = col.Attribute("index")?.Value;
+                    var prop = col.Attribute("property")?.Value;
+                    if (indexAttr != null && prop != null && int.TryParse(indexAttr, out var index))
+                    {
+                        columnMap[index] = prop;
+                    }
+                }
+
+                result[sheetName] = columnMap;
+            }
+        }
+
+        return result;
     }
 
     static WorkbookProtectionInfo? BuildWorkbookProtectionInfo(WorkbookPart workbookPart)
@@ -337,8 +416,11 @@ public static partial class VerifyOpenXml
             Min = min,
             Max = max,
             AllowBlank = dv.AllowBlank?.Value ?? false,
+            ShowInputMessage = dv.ShowInputMessage?.Value ?? false,
             InputTitle = dv.PromptTitle?.Value,
             InputMessage = dv.Prompt?.Value,
+            ShowErrorMessage = dv.ShowErrorMessage?.Value ?? false,
+            ErrorStyle = dv.ErrorStyle?.InnerText,
             ErrorTitle = dv.ErrorTitle?.Value,
             ErrorMessage = dv.Error?.Value,
             Range = range


### PR DESCRIPTION
  - ColumnValidationInfo now exposes ShowInputMessage, ShowErrorMessage, and ErrorStyle so the snapshot reflects whether Excel will actually block invalid input.
  - Add PropertyName on ColumnInfo, sourced from a custom XML part (xmlns="http://schemas.simoncropp.com/excelsior/v1") that producers like Excelsior write to map sheet/column index to the originating C# property name.