### PR TITLE
Bump Morph packages to 1.13.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;CA1416;NU1608;NU1109;SC023</NoWarn>
-    <Version>1.26.0</Version>
+    <Version>1.27.0</Version>
     <LangVersion>14.0</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>OpenXML, Verify</PackageTags>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,18 +6,18 @@
   <ItemGroup>
     <PackageVersion Include="DeterministicIoPackaging" Version="0.30.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.5.1" />
-    <PackageVersion Include="Morph" Version="1.13.0" />
-    <PackageVersion Include="Morph.Skia" Version="1.13.0" />
-    <PackageVersion Include="Morph.ImageSharp" Version="1.13.0" />
+    <PackageVersion Include="Morph" Version="1.13.1" />
+    <PackageVersion Include="Morph.Skia" Version="1.13.1" />
+    <PackageVersion Include="Morph.ImageSharp" Version="1.13.1" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="28.4.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.180" />
-    <PackageVersion Include="Verify" Version="32.0.0-beta.11" />
+    <PackageVersion Include="Verify" Version="31.28.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.3.1" />
-    <PackageVersion Include="Verify.NUnit" Version="32.0.0-beta.11" />
+    <PackageVersion Include="Verify.NUnit" Version="31.28.0" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Argon" Version="0.35.2" />
     <PackageVersion Include="DiffEngine" Version="20.0.0-beta.30" />


### PR DESCRIPTION
Update Morph and its Skia and ImageSharp backends from 1.13.0 to 1.13.1 in central package management so the renderer stack stays aligned on the latest patch release.